### PR TITLE
Embed mutex in system

### DIFF
--- a/ltdiy.go
+++ b/ltdiy.go
@@ -41,12 +41,12 @@ type station struct {
 }
 
 type system struct {
-	Name    string
-	Tagline string
-	Stops   []station
-	TimeMax int
-	stopMap map[string]*station
-	rwLock  *sync.RWMutex
+	sync.RWMutex // Protects everything below
+	Name         string
+	Tagline      string
+	Stops        []station
+	TimeMax      int
+	stopMap      map[string]*station
 }
 
 // Update structures (externally generated)
@@ -93,7 +93,6 @@ var mainSystem system = system{
 	TimeMax: 45,
 
 	stopMap: make(map[string]*station),
-	rwLock:  &sync.RWMutex{},
 }
 
 // Where static files will be found
@@ -127,8 +126,8 @@ func main() {
 // JSON encode all of the information
 func handleInfo(w http.ResponseWriter, r *http.Request) {
 	// Obtain a read lock for the system
-	mainSystem.rwLock.RLock()
-	defer mainSystem.rwLock.RUnlock()
+	mainSystem.RLock()
+	defer mainSystem.RUnlock()
 
 	if err := json.NewEncoder(w).Encode(mainSystem); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -146,8 +145,8 @@ func handleStopInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Obtain a read lock for the system
-	mainSystem.rwLock.RLock()
-	defer mainSystem.rwLock.RUnlock()
+	mainSystem.RLock()
+	defer mainSystem.RUnlock()
 
 	// Try to find the correct stop
 	stop := mainSystem.stopMap[stopID[0]]
@@ -189,8 +188,8 @@ func handleUpdate(w http.ResponseWriter, r *http.Request) {
 
 func processUpdates(u *update) error {
 	// Obtain a writer lock
-	mainSystem.rwLock.Lock()
-	defer mainSystem.rwLock.Unlock()
+	mainSystem.Lock()
+	defer mainSystem.Unlock()
 
 	for _, su := range u.Stops {
 		stop := mainSystem.stopMap[su.StationID]


### PR DESCRIPTION
First off, sorry for another "Go conventions" PR 😝 

When using a mutex to protect all of a struct's data, it's conventional to embed the mutex in the struct ([example](https://github.com/golang/go/blob/f78a4c84ac8ed44aaf331989aa32e40081fd8f13/misc/cgo/test/cthread.go#L16)). 

Also, mutexes are generally named `mu` ([example](https://github.com/golang/go/blob/master/src/net/http/server.go#L246)) when there's only one in a struct (assuming we weren't using the lock to protect everything). 
